### PR TITLE
Add MacOS port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,15 @@
 BUILD ?= obj
 all: $(BUILD)/anc
 
+# If PLAT is unset, try to determine it.
+PLAT ?= $(shell uname | tr '[A-Z]' '[a-z]')
+
 # If ARCH is unset, try to determine the architecture. 
 ARCH ?= $(shell uname -m | \
-	sed 's/\(aarch64\)/arm64/gi' | \
-	sed 's/\(armv7l\)/arm/gi' | \
-	sed 's/\(i[3-6]86\)/x86/gi' | \
-	sed 's/\(x86_64\)/x86-64/gi')
+	sed 's/\(aarch64\)/arm64/g' | \
+	sed 's/\(armv7l\)/arm/g' | \
+	sed 's/\(i[3-6]86\)/x86/g' | \
+	sed 's/\(x86_64\)/x86-64/g')
 
 # Check ARCH against a whitelist.
 ARCH := $(filter arm arm64 x86 x86-64,$(ARCH))
@@ -40,8 +43,8 @@ obj-y += source/profile.o
 obj-y += source/shuffle.o
 obj-y += source/solver.o
 obj-y += source/sysfs.o
-obj-y += source/thread.o
 obj-y += source/path.o
+obj-y += source/platform/thread_$(PLAT).o
 
 anc-obj-y += source/anc.o
 
@@ -100,10 +103,10 @@ $(BUILD)/%.o: %.S $(BUILD)/var/CFLAGS $(config-header)
 $(BUILD)/include/config.h: $(CONFIG)
 	@echo "GEN $@"
 	@mkdir -p $(dir $@)
-	@grep -Pi "^CONFIG_[A-Z_]*=.*$$" $(CONFIG) | \
-		sed 's/^\(.*\)=\(y\|yes\|1\)$$/#define \1 1/gi' | \
-		sed 's/^\(.*\)=\(n\|no\|0\)$$/#undef \1 /gi' | \
-		sed 's/^\(.*\)=\(.*\)$$/#define \1 \2/gi' \
+	@grep -Ei "^CONFIG_[A-Z_]*=.*$$" $(CONFIG) | \
+		sed 's/^\(.*\)=\(y\|yes\|1\)$$/#define \1 1/g' | \
+		sed 's/^\(.*\)=\(n\|no\|0\)$$/#undef \1 /g' | \
+		sed 's/^\(.*\)=\(.*\)$$/#define \1 \2/g' \
 		>> $@
 
 # Rule to clean up output files.

--- a/source/platform/thread_darwin.c
+++ b/source/platform/thread_darwin.c
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <stdlib.h>
+#include <pthread.h>
+#include <mach/thread_act.h>
+#include <mach/thread_policy.h>
+
+int pin_cpu(size_t i)
+{
+	pthread_t thread = pthread_self();
+        thread_port_t mach_thread = pthread_mach_thread_np(thread);
+
+	thread_affinity_policy_data_t policy = { i };
+        thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&policy, 1);
+
+        return 0;
+}

--- a/source/platform/thread_linux.c
+++ b/source/platform/thread_linux.c
@@ -4,8 +4,8 @@
  */
 
 #include <stdlib.h>
-
 #include <pthread.h>
+#include <sched.h>
 
 int pin_cpu(size_t i)
 {


### PR DESCRIPTION
This series of commits adds support for building and running under MacOS.

It extends the build system to understand the notion of platform-specific source files, removes some unneeded GNU-isms from the Makefile, and finally implements `thread.c`'s CPU pinning for MacOS, allowing revanc to compile and run under MacOS hosts.

Example run, showing that there still may be some extra work that needs to be done:
```
4-way set associative L1 d-TLB (32 entries, 2M page 4M page)
4-way set associative L1 d-TLB (64 entries, 4K page)
L1 i-TLB (8 entries, 2M page 4M page)
4-way set associative L1 i-TLB (64 entries, 4K page)
64B prefetch
4-way set associative L2 TLB (512 entries, 4K page)
8-way set associative L1 d-cache (32K, 64B line size)
8-way set associative L1 i-cache (32K, 64B line size)
8-way set associative L2 cache (256K, 64B line size)
12-way set associative L3 cache (6M, 64B line size. inclusive)
Settings:
  runs: 1
  rounds: 10
  page format: default
  cache size: 6M
  cache line size: 64B

Detected CPU name: Intel(R) Core(TM) i7-3615QM CPU @ 2.30GHz

Target VA: 0x1124be000

 ---- RUN 0 ----
level	best line	best page	slot	expected	va
1	23		6		190	190		0x00000000000be000 [OK]
2	18		2		146	146		0x00000000124be000 [OK]
3	0		4		4	4		0x00000001124be000 [OK]
4	20		6		166	0		0x00005301124be000 [!!]
Guessed VA: 0x5301124be000

 ---- STATISTICS ----
Failures: 1 (100.000000%, 1 total)
Slot errors: 1 (25.000000%, 4 total, 1.000000 per run)
Total slot error distances: 166 (166.000000 per run)
```