### PR TITLE
prevent buffer->size being used uninitialized

### DIFF
--- a/source/buffer.c
+++ b/source/buffer.c
@@ -23,7 +23,7 @@ struct buffer *new_buffer(struct page_format *fmt, void *target)
 	if (target)
 		flags |= MAP_FIXED;
 
-	if (!(buffer = malloc(sizeof *buffer)))
+	if (!(buffer = calloc(1,sizeof *buffer)))
 		return NULL;
 
 	for (i = 0, level = fmt->levels; i < fmt->nlevels; ++i, ++level) {


### PR DESCRIPTION
I found this would happen:

source/buffer.c:36: Cannot allocate memory

seemingly due to near-infinity being stored in buffer->size. looks like an uninitialized struct.