### PR TITLE
Fix cmp_uint64 on little-endian machines.

### DIFF
--- a/source/profile.c
+++ b/source/profile.c
@@ -25,7 +25,8 @@ volatile cycles_t timer_cycles;
 
 static int cmp_uint64(const void *lhs, const void *rhs)
 {
-	return memcmp(lhs, rhs, sizeof(uint64_t));
+	uint64_t a = *(uint64_t*)lhs, b = *(uint64_t*)rhs;
+	return a < b ? -1 : (a > b ? 1 : 0);
 }
 
 static FILE *vfopenf(const char *fname, const char *mode, va_list ap)


### PR DESCRIPTION
Using memcmp to compare integers is incorrect on most machines. Fix by dereferencing the uint64_t pointer type and comparing explicitly.